### PR TITLE
Deduplicate reserve fund metric

### DIFF
--- a/Query1-PartialWorking
+++ b/Query1-PartialWorking
@@ -94,7 +94,8 @@ let
       onlyDt     = if out0 = null then Table.SelectRows(coerceD, each [DateHeader] <> null and List.Contains(DateListDates, [DateHeader])) else null,
 
       coerceN    = if out0 = null then Table.TransformColumns(onlyDt, {{"Value", each try Number.From(_) otherwise null, type number}}) else null,
-      out        = if out0 = null then Table.RenameColumns(Table.SelectColumns(coerceN, {"Metric","DateHeader","Value"}), {{"DateHeader","Date"}}) else out0
+      dedupe     = if out0 = null then Table.Distinct(coerceN, {"Metric","DateHeader"}) else null,
+      out        = if out0 = null then Table.RenameColumns(Table.SelectColumns(dedupe, {"Metric","DateHeader","Value"}), {{"DateHeader","Date"}}) else out0
   in out,
 
   // -------- Normalize 2025 CF --------


### PR DESCRIPTION
## Summary
- remove duplicate Allocate to Reserve Fund records emitted from the income statement normalization by deduplicating metric-date combinations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdb98ff490832393eca0ff1d6a12d5