### PR TITLE
Add entity-based CF partial query with dynamic date window

### DIFF
--- a/Query1-PartialWorking-CF
+++ b/Query1-PartialWorking-CF
@@ -1,0 +1,196 @@
+let
+  // ========================
+  // PARAMETERS / NAMED RANGES
+  // ========================
+  Folder          = Excel.CurrentWorkbook(){[Name="CF_Folder"]}[Content]{0}[Column1],
+  EntityLookupTbl = Excel.CurrentWorkbook(){[Name="EntityLookup"]}[Content],
+
+  AllowedEntitiesRaw = List.RemoveNulls(Table.Column(EntityLookupTbl, "Entity")),
+  AllowedEntities    = List.Transform(AllowedEntitiesRaw, each Text.From(_)),
+
+  // ========================
+  // DATE WINDOW (Jan 31, 2024 → Dec 31 five years from today)
+  // ========================
+  StartDate    = #date(2024, 1, 31),
+  CurrentDate  = Date.From(DateTime.LocalNow()),
+  EndDateRaw   = Date.EndOfYear(Date.AddYears(CurrentDate, 5)),
+  EndDate      = if EndDateRaw < StartDate then StartDate else EndDateRaw,
+  DateSequence =
+      if StartDate > EndDate then
+        {StartDate}
+      else
+        List.Generate(
+          () => StartDate,
+          each _ <= EndDate,
+          each Date.EndOfMonth(Date.AddMonths(_, 1))
+        ),
+  DateListDates = List.Distinct(List.Sort(DateSequence, Order.Ascending)),
+  TargetYears   = List.Sort(List.Distinct(List.Transform(DateListDates, each Date.Year(_))), Order.Ascending),
+
+  // ========================
+  // HELPERS
+  // ========================
+  SafeText = (value as any) as text => if value = null then "" else Text.From(value),
+
+  ParseDateAny = (x as any) as nullable date =>
+    let
+      d1 = try if Value.Is(x, type date) then x else null otherwise null,
+      d2 = if d1 <> null then d1 else (try if Value.Is(x, type number) then Date.From(x) else null otherwise null),
+      d3 = if d2 <> null then d2 else (try Date.FromText(Text.From(x), "en-US") otherwise null),
+      d4 = if d3 <> null then d3 else (try Date.From(DateTime.FromText(Text.From(x), "en-US")) otherwise null)
+    in d4,
+
+  DateListValid = List.Distinct(List.RemoveNulls(List.Transform(DateListDates, each ParseDateAny(_)))),
+
+  PickDateColumns = (tbl as table) as list =>
+    let
+      cols = Table.ColumnNames(tbl),
+      keep = List.Select(cols, (cn) =>
+               let d = ParseDateAny(cn)
+               in d <> null and List.Contains(DateListValid, d))
+    in keep,
+
+  DetectEntity = (rec as record) as nullable text =>
+    let
+      searchText = Text.Combine({ SafeText(Record.FieldOrDefault(rec, "Folder Path", null)), SafeText(Record.FieldOrDefault(rec, "Name", null)) }, "|"),
+      matches    = List.Select(AllowedEntities, each Text.Contains(searchText, _, Comparer.OrdinalIgnoreCase)),
+      result     = if List.Count(matches) > 0 then matches{0} else null
+    in result,
+
+  ReadSheetPromote = (fullPath as text, sheetName as text, skipRows as number) as nullable table =>
+    let
+      fxFile = try File.Contents(fullPath),
+      bin    = if fxFile[HasError] then null else Binary.Buffer(fxFile[Value]),
+      fxWB   = if bin = null then null else (try Excel.Workbook(bin, null, true)),
+      wb     = if fxWB = null or fxWB[HasError] then null else fxWB[Value],
+      hasItem = if wb = null then false else List.Contains(Table.Column(wb, "Item"), sheetName),
+      raw     = if hasItem then wb{[Item=sheetName, Kind="Sheet"]}[Data] else null,
+      skipped = if raw = null then null else Table.Skip(raw, skipRows),
+      out     = if skipped = null then null else Table.PromoteHeaders(skipped, [PromoteAllScalars=true])
+    in out,
+
+  NormalizeMetricText = (txt as any) as text =>
+    let
+      raw   = SafeText(txt),
+      upper = Text.Upper(Text.Trim(raw))
+    in upper,
+
+  ExtractMetric = (rec as record, metricMap as list) as nullable text =>
+    let
+      columnsToScan = {"ColA","ColB","ColC","ColD"},
+      rawValues     = List.Transform(columnsToScan, each NormalizeMetricText(Record.FieldOrDefault(rec, _, null))),
+      matches       = List.Select(metricMap, (m) => List.Contains(rawValues, m[Match])),
+      result        = if List.Count(matches) > 0 then matches{0}[Name] else null
+    in result,
+
+  MetricMapIS = {
+    [Match = "GROSS OPERATING PROFIT (LOSS)", Name = "Gross Operating Profit (Loss)"],
+    [Match = "USALI EBITDA", Name = "USALI EBITDA"],
+    [Match = "ALLOCATE TO RESERVE FUND", Name = "Allocate to Reserve Fund"]
+  },
+
+  NormalizeIS = (tbl as table) as table =>
+    let
+      out0       = if Table.ColumnCount(tbl) = 0 then #table({"Metric","Date","Value"}, {}) else null,
+      names      = if out0 = null then Table.ColumnNames(tbl) else {},
+      targets    = {"ColA","ColB","ColC","ColD"},
+      takeN      = if out0 = null then List.Min({List.Count(names), List.Count(targets)}) else 0,
+      indices    = if out0 = null then List.Numbers(0, takeN) else {},
+      pairs      = if out0 = null then List.Transform(indices, each { names{_}, targets{_} }) else {},
+      renamed    = if out0 = null then Table.RenameColumns(tbl, pairs, MissingField.Ignore) else null,
+      dCols      = if out0 = null then PickDateColumns(renamed) else {},
+      base       = if out0 = null then Table.SelectColumns(renamed, List.Union({{"ColA","ColB","ColC","ColD"}, dCols}), MissingField.UseNull) else null,
+      unpivot    = if out0 = null then Table.UnpivotOtherColumns(base, {"ColA","ColB","ColC","ColD"}, "DateHeader", "Value") else null,
+      addMet     = if out0 = null then Table.AddColumn(unpivot, "Metric", each ExtractMetric(_, MetricMapIS), type nullable text) else null,
+      keepMet    = if out0 = null then Table.SelectRows(addMet, each [Metric] <> null) else null,
+      coerceD    = if out0 = null then Table.TransformColumns(keepMet, {{"DateHeader", each ParseDateAny(_), type date}}) else null,
+      onlyDt     = if out0 = null then Table.SelectRows(coerceD, each [DateHeader] <> null and List.Contains(DateListValid, [DateHeader])) else null,
+      coerceN    = if out0 = null then Table.TransformColumns(onlyDt, {{"Value", each try Number.From(_) otherwise null, type number}}) else null,
+      dedupe     = if out0 = null then Table.Distinct(coerceN, {"Metric","DateHeader"}) else null,
+      out        = if out0 = null then Table.RenameColumns(Table.SelectColumns(dedupe, {"Metric","DateHeader","Value"}), {{"DateHeader","Date"}}) else out0
+    in out,
+
+  NormalizeCF = (tbl as table) as table =>
+    let
+      out0       = if Table.ColumnCount(tbl) = 0 then #table({"Metric","Date","Value"}, {}) else null,
+      names      = if out0 = null then Table.ColumnNames(tbl) else {},
+      targets    = {"ColA","ColB","ColC","ColD"},
+      takeN      = if out0 = null then List.Min({List.Count(names), List.Count(targets)}) else 0,
+      indices    = if out0 = null then List.Numbers(0, takeN) else {},
+      pairs      = if out0 = null then List.Transform(indices, each { names{_}, targets{_} }) else {},
+      renamed    = if out0 = null then Table.RenameColumns(tbl, pairs, MissingField.Ignore) else null,
+      dCols      = if out0 = null then PickDateColumns(renamed) else {},
+      base       = if out0 = null then Table.SelectColumns(renamed, List.Union({{"ColA","ColB","ColC","ColD"}, dCols}), MissingField.UseNull) else null,
+      unpivot    = if out0 = null then Table.UnpivotOtherColumns(base, {"ColA","ColB","ColC","ColD"}, "DateHeader", "Value") else null,
+      addMet     = if out0 = null then Table.AddColumn(unpivot, "Metric", each Text.Trim(SafeText(Record.Field(_, "ColC"))), type text) else null,
+      keepMet    = if out0 = null then Table.SelectRows(addMet, each List.Contains({"Debt Service","Cash Generated (Used) After Debt Service"}, [Metric])) else null,
+      coerceD    = if out0 = null then Table.TransformColumns(keepMet, {{"DateHeader", each ParseDateAny(_), type date}}) else null,
+      onlyDt     = if out0 = null then Table.SelectRows(coerceD, each [DateHeader] <> null and List.Contains(DateListValid, [DateHeader])) else null,
+      coerceN    = if out0 = null then Table.TransformColumns(onlyDt, {{"Value", each try Number.From(_) otherwise null, type number}}) else null,
+      out        = if out0 = null then Table.RenameColumns(Table.SelectColumns(coerceN, {"Metric","DateHeader","Value"}), {{"DateHeader","Date"}}) else out0
+    in out,
+
+  ProcessFile = (fullPath as text, fileName as text, entity as nullable text) as table =>
+    let
+      sheetRecords =
+        List.Combine(
+          List.Transform(
+            TargetYears,
+            (yr) => {
+              [Kind = "IS", Table = ReadSheetPromote(fullPath, Text.From(yr) & " IS", 4)],
+              [Kind = "CF", Table = ReadSheetPromote(fullPath, Text.From(yr) & " CF", 4)]
+            }
+          )
+        ),
+      normalizedTables =
+        List.Transform(
+          sheetRecords,
+          (rec) =>
+            let
+              tbl = Record.FieldOrDefault(rec, "Table", null),
+              kind = Record.FieldOrDefault(rec, "Kind", ""),
+              valid = tbl <> null and Value.Is(tbl, type table) and Table.ColumnCount(tbl) > 0
+            in
+              if not valid then
+                #table({"Metric","Date","Value"}, {})
+              else if kind = "IS" then
+                NormalizeIS(tbl)
+              else
+                NormalizeCF(tbl)
+        ),
+      combined = if List.Count(normalizedTables) = 0 then #table({"Metric","Date","Value"}, {}) else Table.Combine(normalizedTables),
+      withEntity = Table.AddColumn(combined, "Entity", each entity, type nullable text),
+      cols       = {"Entity","Metric","Date","Value"},
+      final      = Table.ReorderColumns(Table.SelectColumns(withEntity, cols, MissingField.UseNull), cols, MissingField.UseNull)
+    in final,
+
+  // ========================
+  // TOP-LEVEL FOLDER ONLY (ignore subfolders)
+  // ========================
+  topLevel   = Folder.Contents(Folder),
+  filesOnly  = Table.SelectRows(topLevel, each Record.FieldOrDefault([Attributes], "Directory", false) = false),
+  xlsOnly    = Table.SelectRows(filesOnly, each Text.EndsWith(Text.Lower([Extension]), ".xlsx") or Text.EndsWith(Text.Lower([Extension]), ".xlsm")),
+  xlsSlim    = Table.SelectColumns(xlsOnly, {"Folder Path","Name","Extension","Date modified","Attributes","Content"}),
+
+  withEntity = Table.AddColumn(xlsSlim, "Entity", each DetectEntity(_), type nullable text),
+  onlyAllow  = Table.SelectRows(withEntity, each [Entity] <> null and List.Contains(AllowedEntities, [Entity])),
+
+  entityFileRaw  = Table.SelectColumns(onlyAllow, {"Entity","Folder Path","Name"}, MissingField.Ignore),
+  entityFilePath = Table.AddColumn(entityFileRaw, "File Path", each SafeText([Folder Path]) & SafeText([Name]), type text),
+  EntityFilePathsTbl = Table.Sort(Table.Distinct(Table.SelectColumns(entityFilePath, {"Entity","File Path"}, MissingField.Ignore)), {{"Entity", Order.Ascending}}),
+
+  processed  = Table.AddColumn(onlyAllow, "Data", each ProcessFile([Folder Path] & [Name], [Name], [Entity])),
+  dataTables = List.Transform(processed[Data], each _),
+  combined   = if List.Count(dataTables) = 0 then #table({"Entity","Metric","Date","Value"}, {}) else Table.Combine(dataTables),
+
+  // ========================
+  // LONG TABLE OUTPUT
+  // ========================
+  Entities_Metrics_Long =
+      Table.TransformColumnTypes(combined, {
+          {"Entity", type text}, {"Metric", type text}, {"Date", type date}, {"Value", type number}
+      }),
+
+  Output = Value.ReplaceMetadata(Entities_Metrics_Long, Value.Metadata(Entities_Metrics_Long) & [EntityFilePaths = EntityFilePathsTbl])
+in
+  Output


### PR DESCRIPTION
## Summary
- add a CF-focused variant of the Query1 partial query that reads from the CF_Folder parameter and EntityLookup table
- generate month-end dates from January 31, 2024 through the end of the year five years from today and process matching "YYYY IS"/"YYYY CF" sheets across those years

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db3da756708323915c68f8c563d9b5